### PR TITLE
Expect that a failed background job might not exist.

### DIFF
--- a/switchio/handlers.py
+++ b/switchio/handlers.py
@@ -188,7 +188,7 @@ class EventListener(object):
                 )
             job.fail(resp)  # fail the job
             # always pop failed jobs
-            self.bg_jobs.pop(job_uuid)
+            self.bg_jobs.pop(job_uuid, None)
             # append the id for later lookup and discard?
             self.failed_jobs[resp] += 1
             consumed = True


### PR DESCRIPTION
# Problem
We're getting a `KeyError` when switchio processes unrelated background jobs.
```
Jan 08 10:25:23 (switchio_event_loop[127.0.0.1]) [ERROR] switchio.EventListener@127.0.0.1 handlers.py:187 : Job '657e78dc-35a8-42f5-a486-390a71d541eb' corresponding to session 'None' failed with:
-ERR NORMAL_CLEARING

Jan 08 10:25:23 (switchio_event_loop[127.0.0.1]) [ERROR] switchio.EventLoop@127.0.0.1 loop.py:348 : Failed to process event BACKGROUND_JOB with uid None
Traceback (most recent call last):
  File "/usr/local/src/.virtualenvs/call-handler/lib/python3.5/site-packages/switchio/loop.py", line 272, in _process_event
    consumed, ret = utils.uncons(*handler(e))  # invoke handler
  File "/usr/local/src/.virtualenvs/call-handler/lib/python3.5/site-packages/switchio/handlers.py", line 191, in _handle_bj
    self.bg_jobs.pop(job_uuid)
KeyError: '657e78dc-35a8-42f5-a486-390a71d541eb'
```

# Solution
Expect the background job to maybe not exist.